### PR TITLE
[インフラ] 開発環境でFEアプリをKubernetesで実行できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,25 @@
 - [Docker Desktop](https://www.docker.com/ja-jp/products/personal/)
   - 個人開発のため
   - Kubernetes のプラグインを有効にする
+
+## 実行手順
+
+### 起動
+
+以下のコマンドを実行してローカル PC 上の Kubernetes でアプリケーションを起動します。
+
+```bash
+$ kubectl apply -f local -R
+```
+
+`http://localhost`でアクセスできます。  
+新しい Image を作成した場合は、各 deployment.yaml のバージョンを変更します。  
+ToDo: 自動でバージョンを変更するか、実行時に引数として渡せるかの対応を検討する
+
+### 停止
+
+以下のコマンドを実行してローカル PC 上の Kubernetes でアプリケーションを停止します。
+
+```bash
+$ kubectl delete -f local -R
+```

--- a/local/fe/deployment.yaml
+++ b/local/fe/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shanari-shanari-fe-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: shanari-shanari-fe
+  template:
+    metadata:
+      labels:
+        app: shanari-shanari-fe
+    spec:
+      containers:
+        - name: shanari-shanari-fe
+          image: shanari-shanari-fe:v0.0.1
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          ports:
+            - containerPort: 3000

--- a/local/fe/service.yaml
+++ b/local/fe/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: shanari-shanari-fe-service
+spec:
+  selector:
+    app: shanari-shanari-fe
+  ports:
+    - port: 80
+      targetPort: 3000
+  type: LoadBalancer


### PR DESCRIPTION
#4 のタスクを実施
- ローカルPC上でFEアプリをKubernetesから実行し、ブラウザからアクセスできるように実装